### PR TITLE
Fix: Download button - Udemy class name changes

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -14,12 +14,12 @@
 import formatcode from './helpers/format_code';
 
 // DECLARE html selectors
-const ENCLOSING_ELEMENT_SELECTOR = '.lecture-bookmark-v2--content-container--2f_Tg';
+const ENCLOSING_ELEMENT_SELECTOR = 'lecture-bookmark-v2--content-container--';
 
 // Listen for message from popup.html and pass download request to background job/service worker
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'Download') {
-    let enclosing_tags = document.querySelectorAll(ENCLOSING_ELEMENT_SELECTOR);
+    let enclosing_tags = document.querySelectorAll(`[class^='${ENCLOSING_ELEMENT_SELECTOR}']`);
 
     /* Notes not found */
     if (enclosing_tags.length === 0) {


### PR DESCRIPTION
The class name that encloses note elements in Udemy can have a variant in its ending that may change from user to user or over time. This fix addresses that by using a class attribute that starts with `lecture-bookmark-v2--content-container--` instead of a literal class name. This makes the selector more dynamic and ensures the download button functions for all users.