### PR TITLE
Fix: Separation between notes in generated Markdown File not showing

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -33,7 +33,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     sortedNodeList(enclosing_tags, sortOrder).forEach((tag) => {
       let cloned_tag = tag.cloneNode(true); // deep clone
       let formatted_node = formatcode(cloned_tag, request.payload);
-      newParentNode.appendChild(formatted_node.children[0]);
+      newParentNode.appendChild(formatted_node);
     });
 
     let message = { type: 'Download', payload: newParentNode.outerHTML };

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -14,12 +14,12 @@
 import formatcode from './helpers/format_code';
 
 // DECLARE html selectors
-const ENCLOSING_ELEMENT_SELECTOR = '.lecture-bookmark-v2--content-container--2f_Tg';
+const ENCLOSING_ELEMENT_SELECTOR = 'lecture-bookmark-v2--content-container--';
 
 // Listen for message from popup.html and pass download request to background job/service worker
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'Download') {
-    let enclosing_tags = document.querySelectorAll(ENCLOSING_ELEMENT_SELECTOR);
+    let enclosing_tags = document.querySelectorAll(`[class^='${ENCLOSING_ELEMENT_SELECTOR}']`);
 
     /* Notes not found */
     if (enclosing_tags.length === 0) {


### PR DESCRIPTION
Currently when users click on the checkbox "Add horizontal b/w each section" option, no horizontal lines are generated in the markdown file.

This is due to to only the first child element of `formatted_node` being appended to `newParentNode`, thus excluding the `<hr>` tag that was intended to be passed down. This fix addresses this issue by passing down all child elements inside `formatted_node` down to the NodeHtmlMarkdown translator.

