### PR TITLE
Proposed new feature: add note metadata to generated markdown files

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -1,53 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>My Chrome Extension</title>
-    <link rel="stylesheet" href="popup.css" />
-  </head>
-  <body>
-    <div class="app">
-      <p class="title">Download Udemy Notes</p>
-      <div class="inner-container">
-        <div class="custom-options">
-          <div class="option-container">
-            <label for="sort-order" class="input-container"> sort notes in reverse
-              <input id="sort-order" name="sort-order" type="checkbox" />
-              <span class="checkmark"></span>
-            </label>
-          </div>
-          <div class="option-container">
-            <label for="horizontal-rule" class="input-container"> Add horizontal b/w each section
-              <input id="horizontal-rule" name="horizontal-rule" type="checkbox" />
-              <span class="checkmark"></span>
-            </label>
-          </div>
-          <div class="option-container">
-            <div class="select">
-              <select name="code-lang" id="code-lang">
-                <option selected disabled>code formatting language</option>
-                <option value="javaScript">javaScript</option>
-                <option value="ruby">ruby</option>
-                <option value="python">python</option>
-                <option value="java">java</option>
-                <option value="c">c</option>
-                <option value="cpp">cpp</option>
-                <option value="html">html</option>
-                <option value="css">css</option>
-              </select>
-            </div>
+
+<head>
+  <meta charset="UTF-8" />
+  <title>My Chrome Extension</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+
+<body>
+  <div class="app">
+    <p class="title">Download Udemy Notes</p>
+    <div class="inner-container">
+      <div class="custom-options">
+        <div class="option-container">
+          <label for="sort-order" class="input-container"> Sort notes in reverse
+            <input id="sort-order" name="sort-order" type="checkbox" />
+            <span class="checkmark"></span>
+          </label>
+        </div>
+        <div class="option-container">
+          <label for="horizontal-rule" class="input-container"> Add note divider lines
+            <input id="horizontal-rule" name="horizontal-rule" type="checkbox" />
+            <span class="checkmark"></span>
+          </label>
+        </div>
+        <div class="option-container">
+          <label for="note-metadata" class="input-container"> Add note's metadata
+            <input id="note-metadata" name="note-metadata" type="checkbox" />
+            <span class="checkmark"></span>
+          </label>
+        </div>
+        <div class="option-container">
+          <div class="select">
+            <select name="code-lang" id="code-lang">
+              <option selected disabled>code formatting language</option>
+              <option value="javaScript">javaScript</option>
+              <option value="ruby">ruby</option>
+              <option value="python">python</option>
+              <option value="java">java</option>
+              <option value="c">c</option>
+              <option value="cpp">cpp</option>
+              <option value="html">html</option>
+              <option value="css">css</option>
+            </select>
           </div>
         </div>
-        <div class="button-container">
-          <button id="download-btn" class="button">Download</button>
-        </div>
       </div>
-      <div class="footer">
-        <p> Made with 💖 by <a href="https://github.com/CuriousAlways">avid</a></p>
-      </div>
+      <div class="button-container">
+        <button id="download-btn" class="button">Download</button>
       </div>
     </div>
+    <div class="footer">
+      <p> Made with 💖 by <a href="https://github.com/CuriousAlways">avid</a></p>
+    </div>
+  </div>
+  </div>
 
-    <script src="popup.js" type="module"></script>
-  </body>
+  <script src="popup.js" type="module"></script>
+</body>
+
 </html>

--- a/public/popup.html
+++ b/public/popup.html
@@ -34,14 +34,23 @@
           <div class="select">
             <select name="code-lang" id="code-lang">
               <option selected disabled>code formatting language</option>
-              <option value="javaScript">javaScript</option>
-              <option value="ruby">ruby</option>
-              <option value="python">python</option>
-              <option value="java">java</option>
-              <option value="c">c</option>
-              <option value="cpp">cpp</option>
-              <option value="html">html</option>
-              <option value="css">css</option>
+              <option value="javaScript">JavaScript</option>
+              <option value="typeScript">TypeScript</option>
+              <option value="ruby">Ruby</option>
+              <option value="python">Python</option>
+              <option value="java">Java</option>
+              <option value="c">C</option>
+              <option value="cpp">C++</option>
+              <option value="csharp">C&#x23;</option>
+              <option value="html">HTML</option>
+              <option value="css">CSS</option>
+              <option value="bash">Bash</option>
+              <option value="go">Go</option>
+              <option value="sql">SQL</option>
+              <option value="php">PHP</option>
+              <option value="kotlin">Kotlin</option>
+              <option value="swift">Swift</option>
+              <option value="rust">Rust</option>
             </select>
           </div>
         </div>

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -11,16 +11,21 @@
 // For more information on Content Scripts,
 // See https://developer.chrome.com/extensions/content_scripts
 
-import formatcode from './helpers/format_code';
 import events from './helpers/events';
+import formatTag from './helpers/formatTag';
 
 // DECLARE html selectors
-const ENCLOSING_ELEMENT_SELECTOR = 'lecture-bookmark-v2--content-container--';
+const ENCLOSING_ELEMENT_SELECTOR = 'lecture-bookmark-v2--row--';
+export const NOTE_CONTENT_SELECTOR = 'lecture-bookmark-v2--content-container--';
+export const NOTE_SECTION_NAME_SELECTOR = 'lecture-bookmark-v2--section--';
+export const NOTE_LESSON_NAME_SELECTOR = 'ud-text-sm';
+export const NOTE_DURATION_ENCLOSING_SELECTOR = 'lecture-bookmark-v2--duration--';
+export const NOTE_DURATION_SELECTOR = 'bookmark-';
 
 // Listen for message from popup.html and pass download request to background job/service worker
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === events.download) {
-    handleDownloadEvent(request)
+    handleDownloadEvent(request);
   }
 
   // Send an empty response
@@ -50,12 +55,11 @@ function handleDownloadEvent(request) {
   let sortOrder = request.payload['reverseSort'] || false;
 
   sortedNodeList(enclosing_tags, sortOrder).forEach((tag) => {
-    let cloned_tag = tag.cloneNode(true); // deep clone
-    let formatted_node = formatcode(cloned_tag, request.payload);
-    newParentNode.appendChild(formatted_node);
+    // Format the notes tag with code formatting as well as optional note metadata title
+    const formattedTag = formatTag(tag, request.payload);
+    newParentNode.append(formattedTag);
   });
 
   let message = { type: events.download, payload: newParentNode.outerHTML };
   chrome.runtime.sendMessage(message);
 }
-

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,3 +1,21 @@
-const validCodeLang = ['ruby', 'python', 'javaScript', 'c', 'cpp', 'html', 'css', 'typeScript'];
+const validCodeLang = [
+  'javaScript',
+  'typeScript',
+  'ruby',
+  'python',
+  'java',
+  'c',
+  'cpp',
+  'csharp',
+  'html',
+  'css',
+  'bash',
+  'go',
+  'sql',
+  'php',
+  'kotlin',
+  'swift',
+  'rust',
+];
 
 export default validCodeLang;

--- a/src/helpers/formatTag.js
+++ b/src/helpers/formatTag.js
@@ -1,0 +1,55 @@
+'use strict';
+
+import formatcode from './format_code';
+import {
+  NOTE_CONTENT_SELECTOR,
+  NOTE_DURATION_ENCLOSING_SELECTOR,
+  NOTE_DURATION_SELECTOR,
+  NOTE_LESSON_NAME_SELECTOR,
+  NOTE_SECTION_NAME_SELECTOR,
+} from '../contentScript';
+
+/*
+returns a heading element populated with the note's section name, lesson name and timestamp
+*/
+function createNoteMetadata({ noteSection, noteLesson, noteTimeStamp, separator }) {
+  const heading = document.createElement('h5');
+  heading.innerText = `${noteSection} ${separator} ${noteLesson} ${separator} ${noteTimeStamp}`;
+  return heading;
+}
+
+/*
+  returns a formatted note element with code formatting as well as optional note metadata title
+*/
+function formatTag(tag, options) {
+  let cloned_tag = tag.cloneNode(true); // deep clone
+
+  const noteContentTag = cloned_tag.querySelector(`[class^='${NOTE_CONTENT_SELECTOR}']`);
+  const formatted_content = formatcode(noteContentTag, options);
+
+  const isAddNoteMetadata = options['noteMetadata'] || false;
+
+  if (isAddNoteMetadata) {
+    // Get the note's metadata from their respective markup elements
+    const noteSectionNameText = cloned_tag.querySelector(`[class^='${NOTE_SECTION_NAME_SELECTOR}']`).innerText;
+    const noteLessonNameText = cloned_tag.querySelector(`[class^='${NOTE_LESSON_NAME_SELECTOR}']`).innerText;
+    const noteTimeStampText = cloned_tag
+      .querySelector(`[class^='${NOTE_DURATION_ENCLOSING_SELECTOR}']`)
+      .querySelector(`[id^='${NOTE_DURATION_SELECTOR}']`).innerText;
+
+    // Build a note metadata heading
+    const noteMetadata = createNoteMetadata({
+      noteSection: noteSectionNameText,
+      noteLesson: noteLessonNameText,
+      noteTimeStamp: noteTimeStampText,
+      separator: ' | ',
+    });
+
+    // insert the the metadata heading at the begining of each div
+    formatted_content.prepend(noteMetadata);
+  }
+
+  return formatted_content;
+}
+
+export default formatTag;

--- a/src/popup.js
+++ b/src/popup.js
@@ -8,6 +8,7 @@ import events from './helpers/events';
   const downloadBtn = document.querySelector('#download-btn');
   const sortOrder = document.querySelector('#sort-order');
   const addHorizontalRule = document.querySelector('#horizontal-rule');
+  const addNoteMetadata = document.querySelector('#note-metadata');
   const codeFormatLanguage = document.querySelector('#code-lang');
   const links = document.querySelectorAll('a');
   const UDEMY_HOST = 'www.udemy.com';
@@ -47,8 +48,14 @@ import events from './helpers/events';
   function generatePayload() {
     let reverseSortOrder = sortOrder.checked;
     let horizontalRule = addHorizontalRule.checked;
+    let noteMetadata = addNoteMetadata.checked;
     let codeLang = validCodeLang.includes(codeFormatLanguage.value) ? codeFormatLanguage.value : 'javaScript';
 
-    return { reverseSort: reverseSortOrder, addHorizontalRule: horizontalRule, codeLang: codeLang };
+    return {
+      reverseSort: reverseSortOrder,
+      addHorizontalRule: horizontalRule,
+      noteMetadata: noteMetadata,
+      codeLang: codeLang,
+    };
   }
 })();


### PR DESCRIPTION
Proposed new feature:

Option to add a metadata title tag to each note including:
- Section name and number
- Lesson name and number
- Note timestamp

Presently these are added as h4 tags not for semantics but because otherwise they look huge on most generated markdown files.

The formatting logic has been placed in a new helper file but all necessary selectors needed were kept inside the `contentScripts.js` so they can all be managed in the same place.

I also proposed an amendment to the displayed text for all the options on the UI so they feel more in line with each other.

Updated UI:
![Screenshot 2024-04-02 at 15 59 07](https://github.com/CuriousAlways/udemy-notes-downloader/assets/10909928/95476a83-53f6-4613-b0c8-d4a2136ddc05)

Generated Markdown (preview mode):
![Screenshot 2024-04-02 at 16 00 08](https://github.com/CuriousAlways/udemy-notes-downloader/assets/10909928/e1411248-f086-4131-9167-1640b1ca0f5b)

Generated Markdown (raw):
![Screenshot 2024-04-02 at 16 02 08](https://github.com/CuriousAlways/udemy-notes-downloader/assets/10909928/8e4e9484-618e-421d-ad5e-60dd0fc8d8ee)


