### PR TITLE
Allow extension to work with subdomains on Udemy

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -10,7 +10,7 @@ import events from './helpers/events';
   const addHorizontalRule = document.querySelector('#horizontal-rule');
   const codeFormatLanguage = document.querySelector('#code-lang');
   const links = document.querySelectorAll('a');
-  const UDEMY_HOST = 'www.udemy.com';
+  const UDEMY_HOST_REGEXP = /(?:[a-zA-Z0-9\-]{0,63}\.)?udemy\.com/;
 
   /* make links clickable */
   links.forEach((link) => {
@@ -41,7 +41,7 @@ import events from './helpers/events';
   function valideUrl(tab) {
     let url = new URL(tab.url);
 
-    return url.host === UDEMY_HOST;
+    return UDEMY_HOST_REGEXP.test(url.host);
   }
 
   function generatePayload() {


### PR DESCRIPTION
## Description
Allow the extension to download notes from URLs such as _**organization**_.udemy.com
It's very common for Udemy to create a subdomain for each organization providing Udemy access to its employees. 
This will also make it work with `udemy.com` and not just `www.udemy.com`

## Current behavior
Extension only works on the notes tab if the page URL is `www.udemy.com`, otherwise it displays an error message `Download action only applicable on www.udemy.com` 

## Proposed behavior
Extension should work with any subdomain under `udemy.com`, following the naming convention of subdomains (non-internationalized)
HTML page structure shouldn't differ 
